### PR TITLE
Don't take over SuperTable matrix button

### DIFF
--- a/src/assets/MatrixFieldPreview/dist/css/MatrixFieldPreview.css
+++ b/src/assets/MatrixFieldPreview/dist/css/MatrixFieldPreview.css
@@ -5,8 +5,8 @@
 }
 
 /* Takeover */
-.mfp-matrix-field.mfp-field--takeover .buttons .btngroup,
-.mfp-matrix-field.mfp-field--takeover .buttons .menubtn {
+.mfp-matrix-field.mfp-field--takeover > .buttons .btngroup,
+.mfp-matrix-field.mfp-field--takeover > .buttons .menubtn {
   display: none !important;
 }
 


### PR DESCRIPTION
The button takeover should only apply to the direct child of the matrix block, not any children of a matrix inside a supertable. Should fix #62.