### PR TITLE
Neo and Supertable fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.5.0 - 2022-09-21
+
+Thanks @ttempleton for PR #91, helping to address issues with Neo.
+
+### Added
+
+- Ability to takeover the default Neo block button (addressing issue #85 and potentially #84)
+
+### Fixed
+
+- Fixed inline previews not showing in Neo fields (issue #92)
+- Added/fixed proper modal filtering for Neo fields, now the modal respects the children available to the block (issue #87)
+- Fixed bug with Neo block configuration crashing the previews (issue #88)
+- Fixed Supertable "matrix row" issue, where previews were incorrectly showing in nested Supertable rows for Matrix Fields (issue #96)
+ 
 ## 4.0.4 - 2022-09-06
 
 ### Fixed

--- a/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
+++ b/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
@@ -139,7 +139,12 @@ var MFP = MFP || {};
      * @param {*} config 
      * @returns 
      */
-    getModalButtonSettings: function (config) {
+     getModalButtonSettings: function (config) {
+      if (config["field"]["enableTakeover"]) {
+        return {
+          takeover: true,
+        };
+      }
       return {};
     },
 

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -102,16 +102,15 @@ var MFP = MFP || {};
       var blockHandle = $block.attr("data-type");
       var blockConfig = config["blockTypes"][blockHandle];
 
+      // Add inline preview
       if (!blockConfig["image"] && !blockConfig["description"]) {
         console.warn("No block types configured for this block");
-        return;
+      } else {
+        var inlinePreview = this.createInlinePreview(
+          $block.find("> .fields"),
+          blockConfig
+        );
       }
-
-      // Add inline preview
-      var inlinePreview = this.createInlinePreview(
-        $block.find(".fields"),
-        blockConfig
-      );
 
       // Update the modal button
       this.updateModalButton(input.modalButton, function () {
@@ -158,21 +157,6 @@ var MFP = MFP || {};
      */
     getDataKey: function () {
       return "matrix";
-    },
-
-    /**
-     * Get Modal Button Settings
-     * 
-     * @param {*} config 
-     * @returns 
-     */
-    getModalButtonSettings: function (config) {
-      if (config["field"]["enableTakeover"]) {
-        return {
-          takeover: true,
-        };
-      }
-      return {};
     },
 
     /**

--- a/src/assets/NeoFieldPreview/dist/css/NeoFieldPreview.css
+++ b/src/assets/NeoFieldPreview/dist/css/NeoFieldPreview.css
@@ -27,3 +27,14 @@
 .mfp-neo-field.mfp-field--takeover .mfp-modal-button {
   position: block;
 }
+
+/* Takeover */
+.mfp-neo-field.mfp-field--takeover .ni_buttons .btngroup,
+.mfp-neo-field.mfp-field--takeover .ni_buttons .menubtn {
+  display: none !important;
+}
+
+.mfp-neo-field.mfp-field--takeover .mfp-modal-button {
+  position: static;
+  margin-left: 0;
+}

--- a/src/templates/_includes/settings/fields.twig
+++ b/src/templates/_includes/settings/fields.twig
@@ -2,10 +2,6 @@
 
 {% from "matrix-field-preview/_includes/macros" import assetLocationInput,configWarning  %}
 
-{% if showTakeover is not defined %}
-    {% set showTakeover = true %}
-{% endif %}
-
 <div class="field mfp-settings-table">
     <div class="heading">
         <label>{{ "Configure " ~ type | capitalize ~ " Fields"|t('matrix-field-preview') }}</label>
@@ -18,10 +14,8 @@
         <table id="fields" class="data fullwidth">
             <thead>
                 <th scope="col">{{ type | capitalize ~ " Field"|t('matrix-field-preview') }}</th>
-                <th scope="col">{{ "Image Previews Enabled"|t('matrix-field-preview') }} <span class="info"><p>{{ "Whether or not to show previews for this " ~ type | lower ~ " field in." | t('matrix-field-preview') }}</p></span></th>
-                {% if showTakeover %}
-                    <th scope="col">{{ "Takeover"|t('matrix-field-preview') }} <span class="info"><p>{{ "Take-over the default " ~ type | lower ~" field UI. If disabled, previews will still be available via a separate button" | t('matrix-field-preview') }}</p></span></th>
-                {% endif %}
+                <th scope="col">{{ "Enabled"|t('matrix-field-preview') }} <span class="info"><p>{{ "Whether or not to show previews for this " ~ type | lower ~ " field." | t('matrix-field-preview') }}</p></span></th>
+                <th scope="col">{{ "Takeover"|t('matrix-field-preview') }} <span class="info"><p>{{ "Take-over the default " ~ type | lower ~" field UI. If disabled, previews will still be available via a separate button" | t('matrix-field-preview') }}</p></span></th>
             </thead>
             <tbody>
                 {% for fieldConfig in fieldConfigs %}
@@ -37,15 +31,13 @@
                                 on: fieldConfig.enablePreviews
                             }) }}
                         </td>
-                        {% if showTakeover %}
-                            <td scope="row" data-title="Takeover">
-                                {{ forms.lightswitchField({
-                                    name: 'settings[' ~ field.handle ~ '][enableTakeover]',
-                                    id:  field.handle ~ '-enableTakeover',
-                                    on: fieldConfig.enableTakeover
-                                }) }}
-                            </td>
-                        {% endif %}
+                        <td scope="row" data-title="Takeover">
+                            {{ forms.lightswitchField({
+                                name: 'settings[' ~ field.handle ~ '][enableTakeover]',
+                                id:  field.handle ~ '-enableTakeover',
+                                on: fieldConfig.enableTakeover
+                            }) }}
+                        </td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/src/templates/settings/neo-fields/index.twig
+++ b/src/templates/settings/neo-fields/index.twig
@@ -22,7 +22,6 @@
         <hr>        
     {% endif %}
     {% include "matrix-field-preview/_includes/settings/fields.twig" with {
-        type: "neo",
-        showTakeover: false
+        type: "neo"
     } %}
 {% endblock %}


### PR DESCRIPTION
Thanks @ttempleton for PR #91, helping to address issues with Neo.

### Added

- Ability to takeover the default Neo block button (addressing issue #85 and potentially #84)

### Fixed

- Fixed inline previews not showing in Neo fields (issue #92)
- Added/fixed proper modal filtering for Neo fields, now the modal respects the children available to the block (issue #87)
- Fixed bug with Neo block configuration crashing the previews (issue #88)
- Fixed Supertable "matrix row" issue, where previews were incorrectly showing in nested Supertable rows for Matrix Fields (issue #96)
- Fixed small bug where the page jumps when a preview is clicked in the modal