### PR TITLE
Added support for GIFs when transforms are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.2 - 2023-12-06
+
+### Added
+
+- Support for GIFs when transforms are disabled (issue #119). See the [troubleshooting](https://craft-plugins.timmyomahony.com/matrix-field-preview/docs/troubleshooting) docs for more on issues with GIFs.
+
 ## 4.1.1 - 2023-10-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This visual alternative makes it much easier to see at-a-glance what each block 
   - **Optional**: you don't have to completely _replace_ the default dropdown field, you can choose to instead augment it, giving you the best of both worlds.
 - **Inline previews**: when browsing your entries, get a visual hint as to what each block looks like on the page with our inline previews that are added to all matrix or neo blocks.
 - **Integrations**: Neo, Spoon, MatrixMate & Supertable are all supported out of the box.
+- **GIFs**: use GIFs to make previews even more intuitive.
 
 ## Documentation
 

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -92,12 +92,19 @@ class PreviewController extends Controller
             if ($blockTypeConfig->previewImageId) {
                 $asset = Craft::$app->assets->getAssetById($blockTypeConfig->previewImageId);
                 $result["imageId"] = $blockTypeConfig->previewImageId;
-                $result["image"] = $asset ? $asset->getUrl([
-                    "width" => 800,
-                    "mode" => "fit",
-                    "position" => "center-center",
-                ]) : "";
-                $result["thumb"] = $asset ? $asset->getThumbUrl(300, 300) : "";
+                if ($asset->extension == "gif" && Craft::$app->config->general->transformGifs == false) {
+                    $result["image"] = $asset ? $asset->getUrl() : "";
+                    $result["thumb"] = $asset ? $asset->getUrl() : "";
+                } else {
+                    $result["image"] = $asset ? $asset->getUrl([
+                        "width" => 800,
+                        "mode" => "fit",
+                        "position" => "center-center",
+                    ]) : "";
+                    $result["thumb"] = $asset ? $asset->getThumbUrl(300, 300) : "";
+                }
+
+
             }
             $response['config']["blockTypes"][$blockType->handle] = $result;
         }


### PR DESCRIPTION
## Added

- Support for GIFs when transforms are disabled (issue #119). See the [troubleshooting](https://craft-plugins.timmyomahony.com/matrix-field-preview/docs/troubleshooting) docs for more on issues with GIFs.