### PR TITLE
Support for "enabled"/"disabled" setting in Neo fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.3 - 2024-03-01
+
+### Fixed
+
+- Neo previews now respect the "enabled" tag. (Issue #118 & PR #121)
+
 ## 4.1.2 - 2023-12-06
 
 ### Added
@@ -167,7 +173,7 @@ Note that we've jumped from version 1.X.X to 3.X.X. This is to make it easier an
 ### Changed
 
 - Improved settings page. Setting should now be available without needing to enable the settings (Issue #18).
-- Fixed bug with enabling/disabling "add block" button when max block types reached.
+- Fixed bug with enabling/disabling "add block" button when max block types reached (Issue #71)
 - Fixed deprecation for Composer 2.0 (Issue #43).
 - Fixed bug with block type names (Issue #32).
 - Refactored code base for easier maintenance.

--- a/src/assets/NeoFieldPreview/dist/js/NeoFieldPreview.js
+++ b/src/assets/NeoFieldPreview/dist/js/NeoFieldPreview.js
@@ -111,6 +111,11 @@ var MFP = MFP || {};
       var blockConfig = config["blockTypes"][blockHandle];
       var neoChildBlockTypes = neoBlock.getButtons().getBlockTypes();
 
+      // If blockConfig is undefined, the block type was disabled
+      if (typeof blockConfig === 'undefined') {
+        return
+      }
+
       if (
         config["neo"]["neoDisableForSingleChilden"] &&
         neoChildBlockTypes.length == 1 &&

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -80,7 +80,7 @@ class PreviewController extends Controller
         $blockTypeConfigs = $blockTypeService->getOrCreateByFieldHandle($fieldHandle);
         foreach ($blockTypeConfigs as $blockTypeConfig) {
             $blockType = $blockTypeConfig->blockType;
-            if ($blockType->hasAttribute('enabled') && !$blockType->enabled) {
+            if ($type == "neo" && $blockType->hasAttribute('enabled') && !$blockType->enabled) {
                 continue;
             }
             $result = [

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -80,6 +80,9 @@ class PreviewController extends Controller
         $blockTypeConfigs = $blockTypeService->getOrCreateByFieldHandle($fieldHandle);
         foreach ($blockTypeConfigs as $blockTypeConfig) {
             $blockType = $blockTypeConfig->blockType;
+            if ($blockType->hasAttribute('enabled') && !$blockType->enabled) {
+                continue;
+            }
             $result = [
                 "name" => $blockType->name,
                 "handle" => $blockType->handle,


### PR DESCRIPTION
### Fixed

- Neo previews now respect the "enabled" tag. (Issue #118 & PR #121). Thanks to @ttempleton