### PR TITLE
Craft 5 support

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,10 +1,10 @@
 {
     "pluginName": "Matrix Field Preview",
     "pluginDescription": "Improve the matrix field publishing experience with screenshot previews.",
-    "pluginVersion": "4.0.2",
+    "pluginVersion": "5.0.0",
     "pluginAuthorName": "Timmy O'Mahony ",
     "pluginVendorName": "weareferal",
-    "pluginAuthorUrl": "https://timmyomahony.com",
+    "pluginAuthorUrl": "https://craft-plugins.timmyomahony.com/matrix-field-preview",
     "pluginAuthorGithub": "timmyomahony",
     "codeComments": "yes",
     "pluginComponents": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 5.0.0 - 2024-08-08
 
-**Read Before Updating**
+**🚨 Read Before Updating**
 
 We need to reset the Matrix Field Preview data as part of the Craft 5 upgrade. Unfortunately there's no way to migrate existing data from version 4 to 5, due to the changes in matrix fields in Craft 5 (specifically the migration from "block types" to "entry types").
 
 Therefore, after updating to version 5 you'll need to re-enter titles, descriptions and images for the entry types within your matrix fields. Neo fields are unaffected, as is any other data on your site.
 
-**Matrix Field "Views"**
+**⚠️ Matrix Field "Views"**
 
 Currently, only the "block" view for matrix fields is supported. Support for the "card" and "element index" views will follow shortly in a future update (5.1). This is due to requiring some additions in the Craft codebase to be able to detect these new views in the Craft CP Javascript environment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] 5.0.0 - 2024-08-03
+## 5.0.0 - 2024-08-08
 
-WARNING: We need to reset the Matrix Field Preview data as part of the Craft 5 upgrade. Unfortunately there's no way to migrate existing data from version 4 to 5, due to the changes in matrix fields in Craft 5 (specifically the migration from "block types" to "entry types").
+**Read Before Updating**
 
-After updating to version 5, you'll need to re-enter titles, descriptions and images for the entry types within your matrix fields. Neo fields are unaffected. 
+We need to reset the Matrix Field Preview data as part of the Craft 5 upgrade. Unfortunately there's no way to migrate existing data from version 4 to 5, due to the changes in matrix fields in Craft 5 (specifically the migration from "block types" to "entry types").
+
+Therefore, after updating to version 5 you'll need to re-enter titles, descriptions and images for the entry types within your matrix fields. Neo fields are unaffected, as is any other data on your site.
+
+**Matrix Field "Views"**
+
+Currently, only the "block" view for matrix fields is supported. Support for the "card" and "element index" views will follow shortly in a future update (5.1). This is due to requiring some additions in the Craft codebase to be able to detect these new views in the Craft CP Javascript environment.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased] 5.0.0 - 2024-08-03
 
-TODO
+WARNING: We need to reset the Matrix Field Preview data as part of the Craft 5 upgrade. Unfortunately there's no way to migrate existing data from version 4 to 5, due to the changes in matrix fields in Craft 5 (specifically the migration from "block types" to "entry types").
+
+After updating to version 5, you'll need to re-enter titles, descriptions and images for the entry types within your matrix fields. Neo fields are unaffected. 
+
+### Added
+
+- Craft 5 support
+
+### Fixed
+
+
 
 ## 4.1.3 - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ After updating to version 5, you'll need to re-enter titles, descriptions and im
 
 ### Fixed
 
-
+- Fixed "add block above" issue with Neo fields (see Issue #112 and PR #123)
+- Stop page scroll bug when modal is closed (Issue #106)
 
 ## 4.1.3 - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] 5.0.0 - 2024-08-03
+
+TODO
+
 ## 4.1.3 - 2024-03-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Matrix Field Preview Craft CMS Plugin
 
-🚨 **Craft 5 support is on the way (June 2024)**
-
 ![Header image for plugin](https://craft-plugins-cdn.timmyomahony.com/website/matrix-field-preview/matrix-field-preview-plugin-header.png)
 
 📓 [**Documentation**](https://craft-plugins.timmyomahony.com/matrix-field-preview?utm_source=github&utm_campaign=documentation-launch) | 💳 [**Purchase**](https://plugins.craftcms.com/matrix-field-preview?craft4) | 🤷🏻‍♂️ [**Get help**](https://craft-plugins.timmyomahony.com/matrix-field-preview/docs/get-help)

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0",
+        "craftcms/cms": "^5.0.0",
         "php": "^8.0.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.7",
+        "phpstan/phpstan": "^1.11",
         "craftcms/phpstan": "dev-main",
         "craftcms/rector": "dev-main"
     }

--- a/src/MatrixFieldPreview.php
+++ b/src/MatrixFieldPreview.php
@@ -61,7 +61,7 @@ class MatrixFieldPreview extends Plugin
 {
     public static $plugin;
 
-    public string $schemaVersion = '3.0.3';
+    public string $schemaVersion = '5.0.0';
     public bool $hasCpSettings = true;
     public bool $hasCpSection = false;
 

--- a/src/MatrixFieldPreview.php
+++ b/src/MatrixFieldPreview.php
@@ -158,7 +158,7 @@ class MatrixFieldPreview extends Plugin
                     // be always registered.
                     $view->registerTranslations('matrix-field-preview', [
                         'All Categories',
-                        'Add Block',
+                        'New Entry',
                         'Content Preview',
                         'Matrix Field Previews',
                         'Neo Field Previews',

--- a/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
+++ b/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
@@ -46,7 +46,6 @@ var MFP = MFP || {};
           "afterInit",
           {},
           function (ev) {
-            console.debug("New matrix field initialised on the page with id '#" + ev.target.id + "'");
             this.onInputLoaded(ev.target);
           }.bind(this)
         );

--- a/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
+++ b/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
@@ -40,12 +40,13 @@ var MFP = MFP || {};
       if (typeof this.getInputClass() !== "undefined") {
         this.defaultImageUrl = matrixFieldPreviewDefaultImage;
         this.previewIcon = matrixFieldPreviewIcon;
-
+        
         Garnish.on(
           this.getInputClass(),
           "afterInit",
           {},
           function (ev) {
+            console.debug("New matrix field initialised on the page with id '#" + ev.target.id + "'");
             this.onInputLoaded(ev.target);
           }.bind(this)
         );
@@ -69,6 +70,7 @@ var MFP = MFP || {};
             if (response["success"]) {
               var config = response["config"];
               this.configs[fieldHandle] = config;
+              console.debug("Retrieved config from server for handle '" + fieldHandle + "' :", response["config"]);
               if (!config["field"]["enablePreviews"]) {
                 return;
               }

--- a/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
+++ b/src/assets/BaseFieldPreview/dist/js/BaseFieldPreview.js
@@ -186,6 +186,7 @@ var MFP = MFP || {};
           closeOtherModals: true,
           hideOnEsc: true,
           resizable: false,
+          triggerElement: $target
         },
         config,
         this.defaultImageUrl

--- a/src/assets/BaseFieldPreview/dist/js/BlockTypeInlinePreview.js
+++ b/src/assets/BaseFieldPreview/dist/js/BlockTypeInlinePreview.js
@@ -47,6 +47,7 @@ var MFP = MFP || {};
           $img.fadeOut("fast");
         });
       } else {
+        console.warn("No preview image found for handle " + this.config.handle);
         $thumb.css("background-image", "url('" + this.defaultImageUrl + "')");
       }
 

--- a/src/assets/BaseFieldPreview/dist/js/BlockTypeModal.js
+++ b/src/assets/BaseFieldPreview/dist/js/BlockTypeModal.js
@@ -17,7 +17,9 @@ var MFP = MFP || {};
 
     query: "",
     category: undefined,
-
+    // Used for Neo only: when inserting a block "above" we need to track positioning
+    insertionIndex: undefined,
+  
     /**
      * 
      * @param {*} container 
@@ -258,6 +260,7 @@ var MFP = MFP || {};
           var onClickHandler = function () {
             this.trigger("gridItemClicked", {
               config: blockTypeConfig,
+              insertionIndex: this.insertionIndex
             });
           };
           imgContainer.on("click", onClickHandler.bind(this));

--- a/src/assets/BaseFieldPreview/dist/js/BlockTypeModalButton.js
+++ b/src/assets/BaseFieldPreview/dist/js/BlockTypeModalButton.js
@@ -28,8 +28,8 @@ var MFP = MFP || {};
         this.$target.css("background-image", "url('" + iconUrl + "')");
       } else {
         this.$target
-          .addClass("mfp-modal-button--primary icon add")
-          .text(Craft.t('matrix-field-preview', 'Add Block'));
+          .addClass("mfp-modal-button--primary icon add dashed")
+          .text(Craft.t('matrix-field-preview', 'New Entry'));
       }
 
       this.$target.on(

--- a/src/assets/MatrixFieldPreview/dist/css/MatrixFieldPreview.css
+++ b/src/assets/MatrixFieldPreview/dist/css/MatrixFieldPreview.css
@@ -4,6 +4,10 @@
   top: 0;
 }
 
+.mfp-matrix-field.matrix .buttons {
+  justify-content: space-between;
+}
+
 .mfp-matrix-field.matrix:last-child .buttons {
   margin-bottom: 0 !important;
 }

--- a/src/assets/MatrixFieldPreview/dist/css/MatrixFieldPreview.css
+++ b/src/assets/MatrixFieldPreview/dist/css/MatrixFieldPreview.css
@@ -4,6 +4,10 @@
   top: 0;
 }
 
+.mfp-matrix-field.matrix:last-child .buttons {
+  margin-bottom: 0 !important;
+}
+
 /* Takeover */
 .mfp-matrix-field.mfp-field--takeover > .buttons .btngroup,
 .mfp-matrix-field.mfp-field--takeover > .buttons .menubtn {

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -148,7 +148,7 @@ var MFP = MFP || {};
      */
     blockDeleted: function (input, $block, config) {
       var blockHandle = $block.attr("data-type");
-      
+
       console.debug("Block deleted from matrix field '" + config.field.handle + "' : '" + blockHandle + "'");
     
       // Update the modal button
@@ -186,12 +186,21 @@ var MFP = MFP || {};
 
     /**
      * Get Field Handle
-     *
+     * 
+     * FIXME: Ideally there would be a better approach to getting the matrix
+     * field handle from Craft's matrix field implementations, but that information
+     * doesn't seem to be stored so we have to use the element's CSS ID along with
+     * some regex to pull it.
+     * 
      * @param {*} input
      * @returns
      */
     getFieldHandle: function (input) {
-      return input.id.replace("fields-", "");
+      const regex = /fields-([^-]+)(?!(.*fields-))/g;
+      while ((match = regex.exec(input.id)) !== null) {
+        lastMatch = match[1];
+      }
+      return lastMatch;
     },
   });
 })(jQuery);

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -27,7 +27,7 @@ var MFP = MFP || {};
       }
 
       input.on(
-        "blockAdded",
+        "entryAdded",
         function (ev) {
           this.blockAdded(input, ev.$block, config, true);
         }.bind(this)
@@ -83,7 +83,7 @@ var MFP = MFP || {};
         "gridItemClicked",
         {},
         function (event) {
-          input.addBlock(event.config.handle);
+          input.addEntry(event.config.handle);
           modal.hide();
         }.bind(this)
       );

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -121,6 +121,8 @@ var MFP = MFP || {};
       var blockHandle = $block.attr("data-type");
       var blockConfig = config["blockTypes"][blockHandle];
 
+      console.debug("Block added to matrix field '" + config.field.handle + "' : '" + blockHandle + "'");
+
       // Add inline preview
       if (!blockConfig["image"] && !blockConfig["description"]) {
         console.warn("No block types configured for this block");
@@ -145,6 +147,10 @@ var MFP = MFP || {};
      * @param {*} config
      */
     blockDeleted: function (input, $block, config) {
+      var blockHandle = $block.attr("data-type");
+      
+      console.debug("Block deleted from matrix field '" + config.field.handle + "' : '" + blockHandle + "'");
+    
       // Update the modal button
       this.updateModalButton(input.modalButton, function () {
         return input.canAddMoreEntries();

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -31,14 +31,14 @@ var MFP = MFP || {};
       input.on(
         "entryAdded",
         function (ev) {
-          this.blockAdded(input, ev.$block, config, true);
+          this.blockAdded(input, ev.$entry, config, true);
         }.bind(this)
       );
 
       input.on(
-        "blockDeleted",
+        "entryDeleted",
         function (ev) {
-          this.blockDeleted(input, ev.$block, config);
+          this.blockDeleted(input, ev.$entry, config);
         }.bind(this)
       );
 
@@ -147,7 +147,7 @@ var MFP = MFP || {};
     blockDeleted: function (input, $block, config) {
       // Update the modal button
       this.updateModalButton(input.modalButton, function () {
-        return input.canAddMoreBlocks();
+        return input.canAddMoreEntries();
       });
     },
 

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -17,6 +17,8 @@ var MFP = MFP || {};
     /**
      * Initialise Input
      *
+     * Create listeners on the input
+     * 
      * @param {*} input
      * @param {*} config
      */
@@ -91,7 +93,7 @@ var MFP = MFP || {};
       input.modal = modal;
 
       // Setup all existing blocks
-      var $blocks = input.$blockContainer.children();
+      var $blocks = input.$entriesContainer.children();
       $blocks.each(
         function (i, $block) {
           this.blockAdded(input, $($block), config, false);
@@ -101,6 +103,11 @@ var MFP = MFP || {};
 
     /**
      * Block Added
+     * 
+     * Respond to the matrix field adding a new block by setting
+     * up MFP previews.
+     * 
+     * TODO: Rename to "onEntryAdded"
      *
      * @param {*} input
      * @param {*} $block
@@ -126,7 +133,7 @@ var MFP = MFP || {};
 
       // Update the modal button
       this.updateModalButton(input.modalButton, function () {
-        return input.canAddMoreBlocks();
+        return input.canAddMoreEntries();
       });
     },
 

--- a/src/assets/NeoFieldPreview/dist/css/NeoFieldPreview.css
+++ b/src/assets/NeoFieldPreview/dist/css/NeoFieldPreview.css
@@ -2,11 +2,9 @@
 .mfp-neo-field {
 }
 
-/* Fix the neo tab border */
-.mfp-neo-field .mfp-block-type-preview {
-  padding: 12px 0 0 0;
-  margin: 0;
-  border-top: 1px solid #e3e5e8;
+.mfp-neo-field .ni_block_body > .mfp-block-type-preview {
+  margin: 12px 14px 0 14px;
+  padding: 0;
 }
 
 .mfp-neo-field

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -100,11 +100,12 @@ class PreviewController extends Controller
                     $result["thumb"] = $asset ? $asset->getUrl() : "";
                 } else {
                     $result["image"] = $asset ? $asset->getUrl([
-                        "width" => 800,
+                        "width" => 1600,
                         "mode" => "fit",
                         "position" => "center-center",
+                        "quality" => 99
                     ]) : "";
-                    $result["thumb"] = $asset ? Craft::$app->assets->getThumbUrl($asset, 300, 300) : "";
+                    $result["thumb"] = $asset ? Craft::$app->assets->getThumbUrl($asset, 600, 600) : "";
                 }
 
 

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -104,7 +104,7 @@ class PreviewController extends Controller
                         "mode" => "fit",
                         "position" => "center-center",
                     ]) : "";
-                    $result["thumb"] = $asset ? $asset->getThumbUrl(300, 300) : "";
+                    $result["thumb"] = $asset ? Craft::$app->assets->getThumbUrl($asset, 300, 300) : "";
                 }
 
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -172,7 +172,7 @@ class Install extends Migration
             $this->db->getForeignKeyName('{{%matrixfieldpreview_blocktypes_config}}', 'blockTypeId'),
             '{{%matrixfieldpreview_blocktypes_config}}',
             'blockTypeId',
-            '{{%matrixblocktypes}}',
+            '{{%entrytypes}}',
             'id',
             'CASCADE',
             'CASCADE'

--- a/src/migrations/m240804_214123_converted_blocktype_to_entrytype.php
+++ b/src/migrations/m240804_214123_converted_blocktype_to_entrytype.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace weareferal\matrixfieldpreview\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m240804_214123_converted_blocktype_to_entrytype migration.
+ */
+class m240804_214123_converted_blocktype_to_entrytype extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        // Update the FK field to point to the entrytypes table
+        $this->addForeignKey(
+            $this->db->getForeignKeyName('{{%matrixfieldpreview_blocktypes_config}}', 'blockTypeId'),
+            '{{%matrixfieldpreview_blocktypes_config}}',
+            'blockTypeId',
+            '{{%entrytypes}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+
+        // Unfortunately there's not a way to migrate previous block configs over
+        // to the new entry types that Craft 5 uses for matrix fields. This means
+        // we need to delete any existing configs so that they can be recreated
+        // when the matrix field settings page is next visited by the user.
+        $this->delete('matrixfieldpreview_blocktypes_config');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m240804_214123_converted_blocktype_to_entrytype cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/records/BaseBlockTypeConfigRecord.php
+++ b/src/records/BaseBlockTypeConfigRecord.php
@@ -8,7 +8,7 @@ use Craft;
 use craft\db\ActiveRecord;
 use craft\records\Field;
 use craft\records\Asset;
-use craft\records\MatrixBlockType;
+use craft\records\EntryType;
 
 use weareferal\matrixfieldpreview\records\CategoryRecord;
 

--- a/src/records/MatrixBlockTypeConfigRecord.php
+++ b/src/records/MatrixBlockTypeConfigRecord.php
@@ -8,7 +8,7 @@ use Craft;
 use craft\db\ActiveRecord;
 use craft\records\Asset;
 
-use craft\records\MatrixBlockType;
+use craft\records\EntryType;
 
 use weareferal\matrixfieldpreview\records\BaseBlockTypeConfigRecord;
 
@@ -16,7 +16,7 @@ use weareferal\matrixfieldpreview\records\BaseBlockTypeConfigRecord;
 
 class MatrixBlockTypeConfigRecord extends BaseBlockTypeConfigRecord
 {
-    protected $BlockTypeClass = MatrixBlockType::class;
+    protected $BlockTypeClass = EntryType::class;
 
     public static function tableName()
     {

--- a/src/services/MatrixBlockTypeConfigService.php
+++ b/src/services/MatrixBlockTypeConfigService.php
@@ -15,14 +15,14 @@ class MatrixBlockTypeConfigService extends BaseBlockTypeConfigService
 
     public function getBlockTypeById($blockTypeId)
     {
-        return Craft::$app->matrix->getBlockTypeById($blockTypeId);
+        return Craft::$app->entries->getEntryTypeById($blockTypeId);
     }
 
     public function getBlockTypeByFieldHandle($handle)
     {
         $field = Craft::$app->getFields()->getFieldByHandle($handle);
         if ($field) {
-            return Craft::$app->matrix->getBlockTypesByFieldId($field->id);
+            return $field->getEntryTypes();
         }
         return null;
     }

--- a/src/templates/_includes/settings/block-type.twig
+++ b/src/templates/_includes/settings/block-type.twig
@@ -39,7 +39,7 @@
         name: 'categoryId',
         options: categoryOptions,
         value: blockTypeConfig.categoryId,
-        errors: blockTypeConfig.getErrors("description"),
+        errors: blockTypeConfig.getErrors("category"),
         disabled: (categories | length <= 0)
     }) }}
 

--- a/src/translations/en/matrix-field-preview.php
+++ b/src/translations/en/matrix-field-preview.php
@@ -22,7 +22,7 @@
  */
 return [
     "All Categories" => "All Categories",
-    "Add Block" => "Add Block",
+    "New Entry" => "New Entry",
     "A short description of this {type} preview. Can include markdown." => "A short description of this {type} preview. Can include markdown.",
     "Block Type" => "Block Type",
     "Content Preview" => "Content Preview",


### PR DESCRIPTION

**🚨 Read Before Updating**

We need to reset the Matrix Field Preview data as part of the Craft 5 upgrade. Unfortunately there's no way to migrate existing data from version 4 to 5, due to the changes in matrix fields in Craft 5 (specifically the migration from "block types" to "entry types").

Therefore, after updating to version 5 you'll need to re-enter titles, descriptions and images for the entry types within your matrix fields. Neo fields are unaffected, as is any other data on your site.

**⚠️ Matrix Field "Views"**

Currently, only the "block" view for matrix fields is supported. Support for the "card" and "element index" views will follow shortly in a future update (5.1). This is due to requiring some additions in the Craft codebase to be able to detect these new views in the Craft CP Javascript environment.

### Added

- Craft 5 support

### Fixed

- Fixed "add block above" issue with Neo fields (see Issue #112 and PR #123)
- Stop page scroll bug when modal is closed (Issue #106)