### PR TITLE
Updated previews to handle overridden entry type handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.3.4] - 2025-09-16
+
+### Added
+
+- Previews now handle matrix fields with overridden handles. See issue #137.
+
 ## [5.3.3] - 2025-09-16
 
 ### Added

--- a/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
+++ b/src/assets/MatrixFieldPreview/dist/js/MatrixFieldPreview.js
@@ -18,7 +18,7 @@ var MFP = MFP || {};
      * Initialise Input
      *
      * Create listeners on the input
-     * 
+     *
      * @param {*} input
      * @param {*} config
      */
@@ -85,6 +85,7 @@ var MFP = MFP || {};
         "gridItemClicked",
         {},
         function (event) {
+          console.log(event)
           if (event.targetEntry) {
             input.addEntry(event.config.handle, event.targetEntry);
             modal.targetEntry = null;
@@ -108,7 +109,7 @@ var MFP = MFP || {};
 
     /**
      * Entry Added
-     * 
+     *
      * Respond to the matrix field adding a new entry by setting
      * up MFP previews.
      *
@@ -135,7 +136,7 @@ var MFP = MFP || {};
       } else {
         console.warn("No entry types configured for this entry");
       }
-      
+
       // Update the modal button
       this.updateModalButton(input.modalButton, function () {
         return input.canAddMoreEntries();
@@ -158,7 +159,7 @@ var MFP = MFP || {};
       var blockHandle = $block.attr("data-type");
 
       console.debug("Entry deleted from matrix field '" + config.field.handle + "' : '" + blockHandle + "'");
-    
+
       // Update the modal button
       this.updateModalButton(input.modalButton, function () {
         return input.canAddMoreEntries();
@@ -169,21 +170,21 @@ var MFP = MFP || {};
      * Insert Menu Action
      *
      * Add an action to the matrix field. An action is an inline button in the dropdown menu
-     * to the top-right of every block that lets the user launch the preview modal. 
+     * to the top-right of every block that lets the user launch the preview modal.
      *
-     * @param {*} input 
-     * @param {*} $block 
-     * @param {*} config 
+     * @param {*} input
+     * @param {*} $block
+     * @param {*} config
      */
     insertMenuAction: function (input, $block, config) {
       var buttonLabel = config['field']['buttonLabel'] || Craft.t('matrix-field-preview', 'New Entry');
       var buttonIcon = config['field']['buttonIcon'];
-      
+
       // HACK: The disclosure menu is not available immediately after the
       // block is added, so we need to wait for it to be available.
       setTimeout(function () {
         var disclosureMenu = $block.find(".action-btn").data('disclosureMenu')
-        
+
         if (!disclosureMenu) {
           console.warn("Disclosure menu not found");
           return;
@@ -219,7 +220,7 @@ var MFP = MFP || {};
           dstHr.remove()
           dstUl.remove()
         }
-      }, 250);      
+      }, 250);
     },
 
     /**
@@ -251,12 +252,12 @@ var MFP = MFP || {};
 
     /**
      * Get Field Handle
-     * 
+     *
      * FIXME: Ideally there would be a better approach to getting the matrix
      * field handle from Craft's matrix field implementations, but that information
      * doesn't seem to be stored so we have to use the element's CSS ID along with
      * some regex to pull it.
-     * 
+     *
      * @param {*} input
      * @returns
      */

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -4,6 +4,7 @@ namespace weareferal\matrixfieldpreview\controllers;
 
 use Craft;
 use craft\helpers\Cp;
+use craft\helpers\Json;
 use craft\web\Controller;
 use weareferal\matrixfieldpreview\MatrixFieldPreview;
 use yii\helpers\Markdown;
@@ -59,6 +60,22 @@ class PreviewController extends Controller
             return $this->asJson($response);
         }
 
+        // It's possible to override the handle for entry types in matrix fields. These overrides
+        // appear to only be stored on the matrix field settings object. So we create a lookup
+        // object here for this situation
+        //
+        // https://github.com/timmyomahony/craft-matrix-field-preview/issues/137
+        // https://github.com/craftcms/cms/pull/16453
+        $entryTypeOverrides = [];
+        $fieldSettings = Json::decode($fieldConfig->field->settings);
+        if (isset($fieldSettings['entryTypes'])) {
+            foreach ($fieldSettings['entryTypes'] as $entryType) {
+                if (isset($entryType['handle'])) {
+                    $entryTypeOverrides[$entryType['uid']] = $entryType['handle'];
+                }
+            }
+        }
+
         // Add field info
         $response['config']['field'] = [
             "name" => $fieldConfig->field->name,
@@ -68,6 +85,7 @@ class PreviewController extends Controller
             "buttonLabel" => $fieldConfig->buttonLabel,
             "buttonIcon" => "",
             "buttonIconSvg" => "",
+            "entryTypeOverrides" => $entryTypeOverrides
         ];
 
         // Add button icon SVG if configured
@@ -101,12 +119,19 @@ class PreviewController extends Controller
             $result = [
                 "name" => $blockType->name,
                 "handle" => $blockType->handle,
+                "uid" => $blockType->uid,  // the entry type uid, not ours
                 "description" => $blockTypeConfig->description,
                 "descriptionHTML" => Markdown::process($blockTypeConfig->description),
                 "categoryId" => $blockTypeConfig->categoryId,
                 "image" => null,
                 "thumb" => null,
             ];
+
+            // Deal with the situation where a handle has been overridden, discussed above
+            if (isset($entryTypeOverrides[$blockType->uid])) {
+                $result["handle"] = $entryTypeOverrides[$blockType->uid];
+            }
+
             if ($blockTypeConfig->previewImageId) {
                 $asset = Craft::$app->assets->getAssetById($blockTypeConfig->previewImageId);
                 $result["imageId"] = $blockTypeConfig->previewImageId;


### PR DESCRIPTION
### Added

- Previews now handle matrix fields with overridden handles. See issue #137.