### PR TITLE
Release 5.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 craft-matrix-field-preview.code-workspace
 CLAUDE.md
+.claude
 
 # CRAFT ENVIRONMENT
 .env.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.4] - 2026-01-28
+
+### Added
+
+- Inline lightswitch toggles in settings tables for quickly enabling/disabling field previews and block type previews without navigating to individual edit pages
+
 ## [5.3.5] - 2025-09-16
 
 ### Fixed

--- a/src/controllers/BaseBlockTypesController.php
+++ b/src/controllers/BaseBlockTypesController.php
@@ -59,6 +59,8 @@ abstract class BaseBlockTypesController extends Controller {
             }
 
             // Tabledata is required for use with the existing Craft.VueAdminTable
+            // Note: VueAdminTable callbacks only receive the column value, not the full row,
+            // so we include the ID in the enabled value as a composite object.
             $tableData = [];
             foreach ($blockTypeConfigs as $blockTypeConfig) {
                 $url = UrlHelper::url($this->getEditAction((string) $blockTypeConfig->blockType->id));
@@ -66,11 +68,10 @@ abstract class BaseBlockTypesController extends Controller {
                 $hasPreview = $blockTypeConfig->previewImageId !== null;
                 $category = $blockTypeConfig->categoryId !== null ? $blockTypeConfig->category->name : false;
                 $description = $blockTypeConfig->description;
-                $status = $blockTypeConfig->previewImageId !== null; 
                 array_push($tableData, [
                     "id" => $blockTypeConfig->id,
                     "title" => $blockTypeConfig->blockType->name,
-                    "enabled" => $enabled,
+                    "enabled" => ["id" => $blockTypeConfig->id, "value" => $enabled],
                     "hasPreview" => $hasPreview,
                     "description" => $description,
                     "category" => $category,
@@ -98,7 +99,7 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * Reorder block type configs (for a particular field)
-     * 
+     *
      */
     public function actionReorder()
     {
@@ -109,6 +110,46 @@ abstract class BaseBlockTypesController extends Controller {
         $blockTypeConfigService = $this->getBlockTypeConfigService($plugin);
         $blockTypeConfigIds = Json::decode($this->request->getRequiredBodyParam('ids'));
         $blockTypeConfigService->reorder($blockTypeConfigIds);
+
+        return $this->asJson(['success' => true]);
+    }
+
+    /**
+     * Toggle a block type configuration setting via AJAX
+     *
+     * Used for inline lightswitch toggles in the block types table.
+     */
+    public function actionToggle()
+    {
+        $this->requirePostRequest();
+        $this->requireAcceptsJson();
+
+        $plugin = MatrixFieldPreview::getInstance();
+        $blockTypeConfigService = $this->getBlockTypeConfigService($plugin);
+
+        $blockTypeConfigId = $this->request->getRequiredBodyParam('id');
+        $setting = $this->request->getRequiredBodyParam('setting');
+        $value = $this->request->getRequiredBodyParam('value');
+
+        // Validate the setting name
+        $allowedSettings = ['enabled'];
+        if (!in_array($setting, $allowedSettings)) {
+            throw new BadRequestHttpException("Invalid setting: $setting");
+        }
+
+        $blockTypeConfig = $blockTypeConfigService->getById($blockTypeConfigId);
+        if (!$blockTypeConfig) {
+            throw new BadRequestHttpException("Invalid block type config ID: $blockTypeConfigId");
+        }
+
+        $blockTypeConfig->$setting = (bool)$value;
+
+        if (!$blockTypeConfigService->save($blockTypeConfig)) {
+            return $this->asJson([
+                'success' => false,
+                'error' => Craft::t('matrix-field-preview', 'Couldn\'t save the block type config.')
+            ]);
+        }
 
         return $this->asJson(['success' => true]);
     }

--- a/src/controllers/BaseBlockTypesController.php
+++ b/src/controllers/BaseBlockTypesController.php
@@ -24,7 +24,7 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * Enforce admin privileges
-     * 
+     *
      * But ignore the settings `allowAdminChanges`, allowing users to
      * configure the plugin while on production.
      */
@@ -36,7 +36,7 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * List all block type configurations
-     * 
+     *
      */
     public function actionIndex($templateVars = [])
     {
@@ -48,7 +48,7 @@ abstract class BaseBlockTypesController extends Controller {
 
         $blockTypeConfigService = $this->getBlockTypeConfigService($plugin);
         $fieldsConfigService = $this->getFieldsConfigService($plugin);
-    
+
         $fields = [];
         foreach ($fieldsConfigService->getAllFields() as $field) {
             $fieldConfig = $fieldsConfigService->getOrCreateByFieldHandle($field->handle);
@@ -60,7 +60,7 @@ abstract class BaseBlockTypesController extends Controller {
 
             // Tabledata is required for use with the existing Craft.VueAdminTable
             // Note: VueAdminTable callbacks only receive the column value, not the full row,
-            // so we include the ID in the enabled value as a composite object.
+            // so we include the ID and fieldId in the enabled value as a composite object.
             $tableData = [];
             foreach ($blockTypeConfigs as $blockTypeConfig) {
                 $url = UrlHelper::url($this->getEditAction((string) $blockTypeConfig->blockType->id));
@@ -156,7 +156,7 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * Edit a block type configuration
-     * 
+     *
      * Note that we receive the "blockTypeId" not the "blockTypeConfigId". This
      * is because at the time of loading this action we don't know if the
      * block type configuration actually exists yet.
@@ -169,7 +169,7 @@ abstract class BaseBlockTypesController extends Controller {
 
         $uploadAction = $this->getUploadAction();
         $deleteAction = $this->getDeleteAction();
-    
+
         // Set some frontend variables to help with JavaScript
         $this->view->registerJsVar('uploadImageUrl', $uploadAction);
         $this->view->registerJsVar('deleteImageUrl', $deleteAction);
@@ -180,7 +180,7 @@ abstract class BaseBlockTypesController extends Controller {
         }
 
         $categories = $plugin->categoryService->getAll();
-    
+
         return $this->renderTemplate($this->getEditTemplate(), [
             'blockType' => $blockTypeConfig->blockType,
             'blockTypeConfig' => $blockTypeConfig,
@@ -191,11 +191,11 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * Save a block type configuration
-     * 
+     *
      */
     public function actionSave() {
         $this->requirePostRequest();
-        
+
         $plugin = MatrixFieldPreview::getInstance();
         $settings = $plugin->getSettings();
         $blockTypeConfigService = $this->getBlockTypeConfigService($plugin);
@@ -228,10 +228,10 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * Upload a preview to a block type configuration
-     * 
+     *
      * This image will be uploaded and stored as an asset, viewable just like
      * any other asset.
-     * 
+     *
      * NOTE: We are sending the block type config ID, not the block type ID.
      */
     public function actionUploadPreview()
@@ -287,7 +287,7 @@ abstract class BaseBlockTypesController extends Controller {
 
     /**
      * Delete a preview belonging to a block type configuration
-     * 
+     *
      * NOTE: We are sending the block type config ID, not the block type ID.
      */
     public function actionDeletePreview()
@@ -330,12 +330,12 @@ abstract class BaseBlockTypesController extends Controller {
 
     protected function getFieldsConfigService($plugin)
     {
-        throw new \BadMethodCallException(Craft::t('matrix-field-preview', 'Not implemented')); 
+        throw new \BadMethodCallException(Craft::t('matrix-field-preview', 'Not implemented'));
     }
 
     protected function getBlockTypeConfigService($plugin)
     {
-        throw new \BadMethodCallException(Craft::t('matrix-field-preview', 'Not implemented')); 
+        throw new \BadMethodCallException(Craft::t('matrix-field-preview', 'Not implemented'));
     }
 
     protected function getIndexTemplate()

--- a/src/controllers/BaseFieldsController.php
+++ b/src/controllers/BaseFieldsController.php
@@ -5,6 +5,8 @@ use Craft;
 use craft\web\Controller;
 use craft\helpers\UrlHelper;
 
+use yii\web\BadRequestHttpException;
+
 use weareferal\matrixfieldpreview\assets\MatrixFieldPreviewSettings\MatrixFieldPreviewSettingsAsset;
 use weareferal\matrixfieldpreview\MatrixFieldPreview;
 
@@ -47,14 +49,16 @@ abstract class BaseFieldsController extends Controller
         $fieldConfigs = $service->getAll($sort = true);
 
         // Tabledata is required for use with the existing Craft.VueAdminTable
+        // Note: VueAdminTable callbacks only receive the column value, not the full row,
+        // so we include the ID in each toggle value as a composite object.
         $tableData = [];
-        foreach ($fieldConfigs as $fieldConfig) {                
+        foreach ($fieldConfigs as $fieldConfig) {
             $url = UrlHelper::url($this->getEditAction((string) $fieldConfig->field->id));  // Note field id and not fieldConfig id
             array_push($tableData, [
                 "id" => $fieldConfig->id,
                 "title" => $fieldConfig->field->name,
-                "enablePreviews" => (bool)$fieldConfig->enablePreviews,
-                "enableTakeover" => (bool)$fieldConfig->enableTakeover,
+                "enablePreviews" => ["id" => $fieldConfig->id, "value" => (bool)$fieldConfig->enablePreviews],
+                "enableTakeover" => ["id" => $fieldConfig->id, "value" => (bool)$fieldConfig->enableTakeover],
                 "url" => $url
             ]);
         }
@@ -126,6 +130,46 @@ abstract class BaseFieldsController extends Controller
 
         $this->setSuccessFlash(Craft::t('matrix-field-preview', 'Field config saved.'));
         return $this->redirectToPostedUrl($fieldConfig);
+    }
+
+    /**
+     * Toggle a field configuration setting via AJAX
+     *
+     * Used for inline lightswitch toggles in the fields table.
+     */
+    public function actionToggle()
+    {
+        $this->requirePostRequest();
+        $this->requireAcceptsJson();
+
+        $plugin = MatrixFieldPreview::getInstance();
+        $service = $this->getService($plugin);
+
+        $fieldConfigId = $this->request->getRequiredBodyParam('id');
+        $setting = $this->request->getRequiredBodyParam('setting');
+        $value = $this->request->getRequiredBodyParam('value');
+
+        // Validate the setting name
+        $allowedSettings = ['enablePreviews', 'enableTakeover'];
+        if (!in_array($setting, $allowedSettings)) {
+            throw new BadRequestHttpException("Invalid setting: $setting");
+        }
+
+        $fieldConfig = $service->getById($fieldConfigId);
+        if (!$fieldConfig) {
+            throw new BadRequestHttpException("Invalid field config ID: $fieldConfigId");
+        }
+
+        $fieldConfig->$setting = (bool)$value;
+
+        if (!$service->save($fieldConfig)) {
+            return $this->asJson([
+                'success' => false,
+                'error' => Craft::t('matrix-field-preview', 'Couldn\'t save the field config.')
+            ]);
+        }
+
+        return $this->asJson(['success' => true]);
     }
 
     /**

--- a/src/services/BaseFieldConfigService.php
+++ b/src/services/BaseFieldConfigService.php
@@ -54,6 +54,16 @@ abstract class BaseFieldConfigService extends Component
     }
 
     /**
+     * Get By ID
+     *
+     * Get an individual field config by its ID
+     */
+    public function getById($id)
+    {
+        return $this->FieldRecordConfigClass::findOne(['id' => $id]);
+    }
+
+    /**
      * Get or create a MFP Field Config given the underlying field handle
      *
      */

--- a/src/templates/_includes/settings/block-types.twig
+++ b/src/templates/_includes/settings/block-types.twig
@@ -1,5 +1,3 @@
-{% import '_includes/forms' as forms %}
-
 {% do view.registerAssetBundle('craft\\web\\assets\\admintable\\AdminTableAsset') -%}
 
 {% do view.registerTranslations('matrix-field-preview', [
@@ -12,6 +10,7 @@
     "No {type} fields have been created or enabled for previews yet. Please visit the 'Configure Fields' and enable image previews for your {type} fields.",
     'Not configured yet',
     'Preview Image',
+    "Couldn't save the block type config.",
 ]) %}
 
 <div class="field mfp-settings-table">
@@ -23,6 +22,7 @@
         <p class="warning with-icon">{{ "No {type} fields have been created or enabled for previews yet. Please visit 'Configure Fields' and enable image previews for your {type} fields."|t('matrix-field-preview', params = { type: type | lower }) }}</p>
     {% else %}
         {% js %}
+            var type = "{{ type | lower }}";
             var notConfiguredText = Craft.t('matrix-field-preview', 'Not configured yet');
             var columns = [
                 {
@@ -32,11 +32,16 @@
                 {
                     name: 'enabled',
                     title: Craft.t('matrix-field-preview', 'Enabled'),
-                    callback: function(value) {
-                        if (value === true) {
-                            return '<img class="mfp-settings-table__icon" title="' + value + '" src="{{ assets.success }}">'
-                        }
-                        return '<img class="mfp-settings-table__icon mfp-settings-table__icon--cancel" title="' + notConfiguredText + '" src="{{ assets.cancel }}">'
+                    callback: function(data) {
+                        // data is {id: blockTypeConfigId, value: boolean}
+                        // Add an inline lightswitch to the column allowing the user to update
+                        // this setting without having to visit the page directly
+                        var onClass = data.value ? ' on' : '';
+                        var ariaChecked = data.value ? 'true' : 'false';
+                        return '<button type="button" class="lightswitch small' + onClass + '" ' +
+                               'role="switch" aria-checked="' + ariaChecked + '" ' +
+                               'data-id="' + data.id + '" data-setting="enabled" data-type="' + type + '" >' +
+                               '<div class="lightswitch-container"><div class="handle"></div></div></button>';
                     }
                 },
                 {
@@ -74,9 +79,8 @@
         {% for field in fields %}
             <h4><em>{{ field.name }}</em> {{ type | capitalize ~ " Field" | t("matrix-field-preview") }}</h4>
             <div class="mfp-settings-table__table">
-                <div id="matrix-field-preview-block-types-vue-admin-table-{{ field.id }}"></div>
+                <div id="matrix-field-preview-block-types-vue-admin-table-{{ field.id }}" class="mfp-block-types-table"></div>
                 {% js %}
-                    var type = "{{ type | lower }}";
                     new Craft.VueAdminTable({
                         columns: columns,
                         container: '#matrix-field-preview-block-types-vue-admin-table-{{ field.id }}',
@@ -87,5 +91,42 @@
                 {% endjs %}
             </div>
         {% endfor %}
+
+        {% js %}
+            // Handle the toggling of the inline lightswitches in the block types tables.
+            // This is a little bit hacky as we have to use a timeout to wait for the
+            // VueAdminTable to finish rendering the lightswitches as part of the callback
+            // for each column. The Craft VueAdminTable implementation implicitly calls
+            // initUiElements to set up the lightswitches, but there's no easy way to add
+            // a click/change handler, so we simply wait until they're ready and add a
+            // handler manually.
+            setTimeout(function() {
+                $('.mfp-settings-table__table .lightswitch').on('change', function() {
+                    var $lightswitch = $(this);
+                    var lightswitchInstance = $lightswitch.data('lightswitch');
+                    var isOn = lightswitchInstance.on;
+                    var id = $lightswitch.data('id');
+                    var setting = $lightswitch.data('setting');
+                    var blockType = $lightswitch.data('type');
+
+                    // Save to server
+                    Craft.sendActionRequest('POST', 'matrix-field-preview/' + blockType + '-block-types/toggle', {
+                        data: {
+                            id: id,
+                            setting: setting,
+                            value: isOn ? 1 : 0
+                        }
+                    }).catch(function() {
+                        // Revert using Craft's lightswitch API
+                        if (isOn) {
+                            lightswitchInstance.turnOff();
+                        } else {
+                            lightswitchInstance.turnOn();
+                        }
+                        Craft.cp.displayError(Craft.t('matrix-field-preview', 'Couldn\'t save the block type config.'));
+                    });
+                });
+            }, 500);
+        {% endjs %}
     {% endif %}
 </div>

--- a/src/templates/_includes/settings/block-types.twig
+++ b/src/templates/_includes/settings/block-types.twig
@@ -94,14 +94,10 @@
 
         {% js %}
             // Handle the toggling of the inline lightswitches in the block types tables.
-            // This is a little bit hacky as we have to use a timeout to wait for the
-            // VueAdminTable to finish rendering the lightswitches as part of the callback
-            // for each column. The Craft VueAdminTable implementation implicitly calls
-            // initUiElements to set up the lightswitches, but there's no easy way to add
-            // a click/change handler, so we simply wait until they're ready and add a
-            // handler manually.
+            // Use a timeout to wait for VueAdminTable to finish rendering and
+            // initializing the lightswitches via initUiElements.
             setTimeout(function() {
-                $('.mfp-settings-table__table .lightswitch').on('change', function() {
+                $('.mfp-settings-table .lightswitch').on('change', function() {
                     var $lightswitch = $(this);
                     var lightswitchInstance = $lightswitch.data('lightswitch');
                     var isOn = lightswitchInstance.on;
@@ -126,7 +122,7 @@
                         Craft.cp.displayError(Craft.t('matrix-field-preview', 'Couldn\'t save the block type config.'));
                     });
                 });
-            }, 500);
+            }, 100);
         {% endjs %}
     {% endif %}
 </div>

--- a/src/templates/_includes/settings/fields.twig
+++ b/src/templates/_includes/settings/fields.twig
@@ -1,14 +1,13 @@
-{% import '_includes/forms' as forms %}
-
 {% do view.registerAssetBundle('craft\\web\\assets\\admintable\\AdminTableAsset') -%}
 
 {% do view.registerTranslations('matrix-field-preview', [
-    "Enabled",
-    "Matrix Field",
+    "Configure {type} fields",
     "No {type} fields exist yet. Create some fields via the control panel and return here to enable image previews.",
-    "Neo Field",
-    "Takeover",
     "Use this page to configure which {type} fields will display previews.",
+    "Field name",
+    "Previews Enabled",
+    "Takeover Enabled",
+    "No fields exist yet.",
     "Couldn't save the field config.",
 ]) %}
 
@@ -90,7 +89,7 @@
                             setting: setting,
                             value: isOn ? 1 : 0
                         }
-                    }).catch(function(error) {
+                    }).catch(function() {
                         // Revert using Craft's lightswitch API
                         if (isOn) {
                             lightswitchInstance.turnOff();
@@ -100,7 +99,7 @@
                         Craft.cp.displayError(Craft.t('matrix-field-preview', 'Couldn\'t save the field config.'));
                     });
                 });
-            }, 100)
+            }, 100);
         {% endjs %}
     {% endif %}
 </div>

--- a/src/templates/_includes/settings/fields.twig
+++ b/src/templates/_includes/settings/fields.twig
@@ -9,6 +9,10 @@
     "Neo Field",
     "Takeover",
     "Use this page to configure which {type} fields will display previews.",
+    "Previews enabled for this field",
+    "Previews not enabled for this field",
+    "Takeover enabled for this field",
+    "Takeover not enabled for this field",
 ]) %}
 
 <div class="field mfp-settings-table">
@@ -25,7 +29,6 @@
             <div id="matrix-field-preview-fields-vue-admin-table"></div>
         </div>
         {% js %}
-            var notEnabledText = Craft.t('matrix-field-preview', 'Not enabled');
             var columns = [
                 {
                     name: '__slot:title',
@@ -34,21 +37,35 @@
                 {
                     name: 'enablePreviews',
                     title: Craft.t('matrix-field-preview', 'Previews Enabled'),
-                    callback: function(value) {
-                        if (value === true) {
-                            return '<img class="mfp-settings-table__icon" src="{{ assets.success }}" title="{{ 'Previews enabled for this field' | t('matrix-field-preview') }}">'
-                        }
-                        return '<img class="mfp-settings-table__icon mfp-settings-table__icon--cancel" title="{{ 'Previews not enabled for this field' | t('matrix-field-preview') }}" src="{{ assets.cancel }}">'
+                    callback: function(data) {
+                        // data is {id: fieldConfigId, value: boolean}
+                        var onClass = data.value ? ' on' : '';
+                        var ariaChecked = data.value ? 'true' : 'false';
+                        var title = data.value
+                            ? Craft.t('matrix-field-preview', 'Previews enabled for this field')
+                            : Craft.t('matrix-field-preview', 'Previews not enabled for this field');
+                        return '<button type="button" class="lightswitch small' + onClass + '" ' +
+                               'role="switch" aria-checked="' + ariaChecked + '" ' +
+                               'title="' + title + '" ' +
+                               'data-id="' + data.id + '" data-setting="enablePreviews">' +
+                               '<div class="lightswitch-container"><div class="handle"></div></div></button>';
                     }
                 },
                 {
                     name: 'enableTakeover',
                     title: Craft.t('matrix-field-preview', 'Takeover Enabled'),
-                    callback: function(value) {
-                        if (value === true) {
-                            return '<img class="mfp-settings-table__icon" src="{{ assets.success }}" title="{{ 'Takeover enabled for this field' | t('matrix-field-preview') }}">'
-                        }
-                        return '<img class="mfp-settings-table__icon mfp-settings-table__icon--cancel" title="{{ 'Takeover not enabled for this field' | t('matrix-field-preview') }}" src="{{ assets.cancel }}">'
+                    callback: function(data) {
+                        // data is {id: fieldConfigId, value: boolean}
+                        var onClass = data.value ? ' on' : '';
+                        var ariaChecked = data.value ? 'true' : 'false';
+                        var title = data.value
+                            ? Craft.t('matrix-field-preview', 'Takeover enabled for this field')
+                            : Craft.t('matrix-field-preview', 'Takeover not enabled for this field');
+                        return '<button type="button" class="lightswitch small' + onClass + '" ' +
+                               'role="switch" aria-checked="' + ariaChecked + '" ' +
+                               'title="' + title + '" ' +
+                               'data-id="' + data.id + '" data-setting="enableTakeover">' +
+                               '<div class="lightswitch-container"><div class="handle"></div></div></button>';
                     }
                 }
             ];
@@ -58,6 +75,42 @@
                 container: '#matrix-field-preview-fields-vue-admin-table',
                 emptyMessage: Craft.t('matrix-field-preview', 'No fields exist yet.'),
                 tableData: {{ tableData|json_encode|raw }}
+            });
+
+            // Handle lightswitch toggle clicks
+            $('#matrix-field-preview-fields-vue-admin-table').on('click', '.lightswitch', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+
+                var $lightswitch = $(this);
+                var isOn = $lightswitch.hasClass('on');
+                var id = $lightswitch.data('id');
+                var setting = $lightswitch.data('setting');
+                var newValue = !isOn;
+
+                // Toggle visual state immediately
+                $lightswitch.toggleClass('on');
+                $lightswitch.attr('aria-checked', newValue ? 'true' : 'false');
+
+                // Update title
+                var titleKey = setting === 'enablePreviews'
+                    ? (newValue ? 'Previews enabled for this field' : 'Previews not enabled for this field')
+                    : (newValue ? 'Takeover enabled for this field' : 'Takeover not enabled for this field');
+                $lightswitch.attr('title', Craft.t('matrix-field-preview', titleKey));
+
+                // Save to server
+                Craft.sendActionRequest('POST', 'matrix-field-preview/' + type + '-fields/toggle', {
+                    data: {
+                        id: id,
+                        setting: setting,
+                        value: newValue ? 1 : 0
+                    }
+                }).catch(function(error) {
+                    // Revert on error
+                    $lightswitch.toggleClass('on');
+                    $lightswitch.attr('aria-checked', isOn ? 'true' : 'false');
+                    Craft.cp.displayError(Craft.t('matrix-field-preview', 'Couldn\'t save the field config.'));
+                });
             });
         {% endjs %}
     {% endif %}

--- a/src/templates/_includes/settings/fields.twig
+++ b/src/templates/_includes/settings/fields.twig
@@ -9,10 +9,7 @@
     "Neo Field",
     "Takeover",
     "Use this page to configure which {type} fields will display previews.",
-    "Previews enabled for this field",
-    "Previews not enabled for this field",
-    "Takeover enabled for this field",
-    "Takeover not enabled for this field",
+    "Couldn't save the field config.",
 ]) %}
 
 <div class="field mfp-settings-table">
@@ -29,6 +26,7 @@
             <div id="matrix-field-preview-fields-vue-admin-table"></div>
         </div>
         {% js %}
+            var type = "{{ type | lower }}";
             var columns = [
                 {
                     name: '__slot:title',
@@ -38,16 +36,13 @@
                     name: 'enablePreviews',
                     title: Craft.t('matrix-field-preview', 'Previews Enabled'),
                     callback: function(data) {
-                        // data is {id: fieldConfigId, value: boolean}
+                        // Add an inline lightswitch to the column allowing the user to update
+                        // this setting without having to visit the page directly
                         var onClass = data.value ? ' on' : '';
                         var ariaChecked = data.value ? 'true' : 'false';
-                        var title = data.value
-                            ? Craft.t('matrix-field-preview', 'Previews enabled for this field')
-                            : Craft.t('matrix-field-preview', 'Previews not enabled for this field');
                         return '<button type="button" class="lightswitch small' + onClass + '" ' +
                                'role="switch" aria-checked="' + ariaChecked + '" ' +
-                               'title="' + title + '" ' +
-                               'data-id="' + data.id + '" data-setting="enablePreviews">' +
+                               'data-id="' + data.id + '" data-setting="enablePreviews" data-type="' + type + '" >' +
                                '<div class="lightswitch-container"><div class="handle"></div></div></button>';
                     }
                 },
@@ -55,21 +50,18 @@
                     name: 'enableTakeover',
                     title: Craft.t('matrix-field-preview', 'Takeover Enabled'),
                     callback: function(data) {
-                        // data is {id: fieldConfigId, value: boolean}
+                        // Add an inline lightswitch to the column allowing the user to update
+                        // this setting without having to visit the page directly
                         var onClass = data.value ? ' on' : '';
                         var ariaChecked = data.value ? 'true' : 'false';
-                        var title = data.value
-                            ? Craft.t('matrix-field-preview', 'Takeover enabled for this field')
-                            : Craft.t('matrix-field-preview', 'Takeover not enabled for this field');
                         return '<button type="button" class="lightswitch small' + onClass + '" ' +
                                'role="switch" aria-checked="' + ariaChecked + '" ' +
-                               'title="' + title + '" ' +
-                               'data-id="' + data.id + '" data-setting="enableTakeover">' +
+                               'data-id="' + data.id + '" data-setting="enableTakeover" data-type="' + type + '" >' +
                                '<div class="lightswitch-container"><div class="handle"></div></div></button>';
                     }
                 }
             ];
-            var type = "{{ type | lower }}";
+
             new Craft.VueAdminTable({
                 columns: columns,
                 container: '#matrix-field-preview-fields-vue-admin-table',
@@ -77,41 +69,38 @@
                 tableData: {{ tableData|json_encode|raw }}
             });
 
-            // Handle lightswitch toggle clicks
-            $('#matrix-field-preview-fields-vue-admin-table').on('click', '.lightswitch', function(e) {
-                e.preventDefault();
-                e.stopPropagation();
+            // Handle the toggling of the inline lightswitches in the table. This is a little bit
+            // hacky as we have to use a timeout to wait for the VueAdminTable to finish rendering the
+            // lightswitches as part of the callback for each column. The Craft VueAdminTable implementation
+            // implicitly calls the initUiElements to set up the lightswitches, but there's no easy
+            // way to add a click/change handler, so we simply wait until they're ready and add a
+            // handler manually
+            setTimeout(function() {
+                $('#matrix-field-preview-fields-vue-admin-table .lightswitch').on('change', function() {
+                    var $lightswitch = $(this);
+                    var lightswitchInstance = $lightswitch.data('lightswitch');
+                    var isOn = lightswitchInstance.on;
+                    var id = $lightswitch.data('id');
+                    var setting = $lightswitch.data('setting');
 
-                var $lightswitch = $(this);
-                var isOn = $lightswitch.hasClass('on');
-                var id = $lightswitch.data('id');
-                var setting = $lightswitch.data('setting');
-                var newValue = !isOn;
-
-                // Toggle visual state immediately
-                $lightswitch.toggleClass('on');
-                $lightswitch.attr('aria-checked', newValue ? 'true' : 'false');
-
-                // Update title
-                var titleKey = setting === 'enablePreviews'
-                    ? (newValue ? 'Previews enabled for this field' : 'Previews not enabled for this field')
-                    : (newValue ? 'Takeover enabled for this field' : 'Takeover not enabled for this field');
-                $lightswitch.attr('title', Craft.t('matrix-field-preview', titleKey));
-
-                // Save to server
-                Craft.sendActionRequest('POST', 'matrix-field-preview/' + type + '-fields/toggle', {
-                    data: {
-                        id: id,
-                        setting: setting,
-                        value: newValue ? 1 : 0
-                    }
-                }).catch(function(error) {
-                    // Revert on error
-                    $lightswitch.toggleClass('on');
-                    $lightswitch.attr('aria-checked', isOn ? 'true' : 'false');
-                    Craft.cp.displayError(Craft.t('matrix-field-preview', 'Couldn\'t save the field config.'));
+                    // Save to server
+                    Craft.sendActionRequest('POST', 'matrix-field-preview/' + type + '-fields/toggle', {
+                        data: {
+                            id: id,
+                            setting: setting,
+                            value: isOn ? 1 : 0
+                        }
+                    }).catch(function(error) {
+                        // Revert using Craft's lightswitch API
+                        if (isOn) {
+                            lightswitchInstance.turnOff();
+                        } else {
+                            lightswitchInstance.turnOn();
+                        }
+                        Craft.cp.displayError(Craft.t('matrix-field-preview', 'Couldn\'t save the field config.'));
+                    });
                 });
-            });
+            }, 100)
         {% endjs %}
     {% endif %}
 </div>


### PR DESCRIPTION
### Added

- Inline lightswitch toggles in settings tables for quickly enabling/disabling field previews and block type previews without navigating to individual edit pages